### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudtasks",
     "name_pretty": "Cloud Tasks",
     "product_documentation": "https://cloud.google.com/tasks/docs/",
-    "client_documentation": "https://googleapis.dev/python/cloudtasks/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudtasks/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5433985",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.