### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudtasks",
     "name_pretty": "Cloud Tasks",
     "product_documentation": "https://cloud.google.com/tasks/docs/",
-    "client_documentation": "https://googleapis.dev/python/cloudtasks/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudtasks/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5433985",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ requests.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-tasks.svg
    :target: https://pypi.org/project/google-cloud-tasks/
 .. _Cloud Tasks API: https://cloud.google.com/tasks
-.. _Client Library Documentation: https://googleapis.dev/python/cloudtasks/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudtasks/latest
 .. _Product Documentation:  https://cloud.google.com/tasks
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.